### PR TITLE
Calcul de la position des beacons selon laset + bug

### DIFF
--- a/localization/triangulation_gr14.h
+++ b/localization/triangulation_gr14.h
@@ -16,7 +16,10 @@ void fixed_beacon_positions(int team_id, double *x_beac_1, double *y_beac_1,
 	double *x_beac_2, double *y_beac_2, double *x_beac_3, double *y_beac_3);
 int index_predicted(double alpha_predicted, double alpha_a, double alpha_b, double alpha_c);
 void triangulation(CtrlStruct *cvs);
+
 double predicted_angle(double x_r,double y_r,double x_b,double y_b,double alpha,double d);
+
+double normalize_angle(double alpha);
 
 NAMESPACE_CLOSE();
 


### PR DESCRIPTION
J'ai ajouté le calcul des angles que voit le robot avec le laser, il faut juste prendre en compte le cas ou le beacon se trouve dans la zone -pi,pi et faire différent cas.
Ensuite je normalise les angles pour que ils soient dans le domaine 0,2Pi et exploitable par l'algorithme de triangulation qu'adrien a mis en place.  
